### PR TITLE
Update Finnish address stopwords

### DIFF
--- a/text_anonymizer/recognizers/fi_address_recognizer.py
+++ b/text_anonymizer/recognizers/fi_address_recognizer.py
@@ -54,7 +54,7 @@ class FiAddressRecognizer(PatternRecognizer):
     ) -> List[RecognizerResult]:
         return super().analyze(text, entities, nlp_artifacts, regex_flags=re.X)
 
-    STOPWORDS = ['hteystieto']
+    STOPWORDS = ['yhteystieto']
 
     def invalidate_result(self, pattern_text: str) -> bool:
         """


### PR DESCRIPTION
## Summary
- correct typo in FiAddressRecognizer stopword list

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'phonenumbers')*

------
https://chatgpt.com/codex/tasks/task_e_68497db48eb48327b5d94d65cbff9f2f