### PR TITLE
Improve Finnish location recognition

### DIFF
--- a/text_anonymizer/default_settings.py
+++ b/text_anonymizer/default_settings.py
@@ -17,7 +17,10 @@ DEFAULT_SETTINGS.mask_mapppings = {
     'REAL_PROPERTY_ID': 'KIINTEISTÖTUNNUS',
     'PERSON': 'NIMI',
     'GRANTLISTED': 'GRANTLISTED',
-    'FILENAME': 'TIEDOSTONIMI'
+    'FILENAME': 'TIEDOSTONIMI',
+    'DATE': 'PÄIVÄMÄÄRÄ',
+    'LOC': 'PAIKKA',
+    'GPE': 'PAIKKA'
 }
 DEFAULT_SETTINGS.mask_mappings_debug = {
     'ETUNIMI': 'VOIKKO_ETU_NIMI',
@@ -37,6 +40,9 @@ DEFAULT_SETTINGS.mask_mappings_debug = {
     'OTHER': 'TUNNISTE',
     'REAL_PROPERTY_ID': 'KIINTEISTÖTUNNUS',
     'PERSON': 'SPACY_NIMI',
+    'DATE': 'SPACY_PÄIVÄMÄÄRÄ',
+    'LOC': 'SPACY_PAIKKA',
+    'GPE': 'SPACY_PAIKKA',
 }
 
 DEFAULT_SETTINGS.operator_config = {
@@ -50,6 +56,7 @@ DEFAULT_SETTINGS.recognizer_configuration = [RECOGNIZER_EMAIL,
                                              RECOGNIZER_IP,
                                              RECOGNIZER_IBAN,
                                              RECOGNIZER_REGISTRATION_PLATE,
+                                             RECOGNIZER_ADDRESS,
                                              RECOGNIZER_BLOCKLIST,
                                              RECOGNIZER_GRANTLIST,
                                              RECOGNIZER_PROPERTY,

--- a/text_anonymizer/text_anonymizer.py
+++ b/text_anonymizer/text_anonymizer.py
@@ -163,9 +163,10 @@ class TextAnonymizer:
 
         if RECOGNIZER_SPACY_FI in self.recognizer_configuration:
             # Finnish spacy recognizer
-            finnish_spacy_recognizer = SpacyRecognizer(ner_strength=0.90,
-                                                       supported_entities=['PERSON', 'DATE'],
-                                                       supported_language='fi')
+            finnish_spacy_recognizer = SpacyRecognizer(
+                ner_strength=0.90,
+                supported_entities=['PERSON', 'DATE', 'LOC', 'GPE'],
+                supported_language='fi')
             self.registry.add_recognizer(finnish_spacy_recognizer)
 
         if RECOGNIZER_SPACY_EN in self.recognizer_configuration:
@@ -176,8 +177,10 @@ class TextAnonymizer:
             self.registry.add_recognizer(english_spacy_recognizer)
 
         if RECOGNIZER_SPACY_ADDRESS in self.recognizer_configuration:
-            # Finnish spacy recognizer
-            address_spacy_recognizer = SpacyAddressRecognizer(anonymize_full_string=False, supported_entity='ADDRESS')
+            # Finnish spacy address recognizer
+            address_spacy_recognizer = SpacyAddressRecognizer(
+                anonymize_full_string=True,
+                supported_entity='ADDRESS')
             self.registry.add_recognizer(address_spacy_recognizer)
 
         # Init engines


### PR DESCRIPTION
## Summary
- mask dates and locations with PÄIVÄMÄÄRÄ / PAIKKA labels
- recognise Finnish addresses by default
- expand spaCy recognizer to detect `LOC` and `GPE`
- anonymize full street address

## Testing
- `pytest -q` *(fails: ImportError phonenumbers)*

------
https://chatgpt.com/codex/tasks/task_e_6849ea39a260832790e18eb53cc44bec