### PR TITLE
Add helper for model version and update scripts

### DIFF
--- a/get_model_version.py
+++ b/get_model_version.py
@@ -1,0 +1,12 @@
+import json
+from pathlib import Path
+
+META_PATH = Path(__file__).resolve().parent / "custom_spacy_model" / "meta.json"
+
+def get_model_version() -> str:
+    with META_PATH.open() as f:
+        data = json.load(f)
+    return data.get("version", "")
+
+if __name__ == "__main__":
+    print(get_model_version())

--- a/train_custom_spacy_model/docker_train_custom_spacy_model.sh
+++ b/train_custom_spacy_model/docker_train_custom_spacy_model.sh
@@ -1,9 +1,10 @@
 #!/bin/sh
-if [ ! -d "/app/custom_spacy_model/fi_datahel_spacy-0.0.2" ]; then
+VERSION=$(python /app/get_model_version.py)
+if [ ! -d "/app/custom_spacy_model/fi_datahel_spacy-${VERSION}" ]; then
     echo "Custom spacy model not found, training..."
     python ./train_custom_spacy_model.py
-  cp template_meta.json ../custom_spacy_model/fi_datahel_spacy-0.0.2/meta.json
-  cp template_config.cfg ../custom_spacy_model/fi_datahel_spacy-0.0.2/config.cfg
+    cp template_meta_spacy_fi_lg.json ../custom_spacy_model/fi_datahel_spacy-${VERSION}/meta.json
+    cp template_config_spacy_fi_lg.cfg ../custom_spacy_model/fi_datahel_spacy-${VERSION}/config.cfg
 fi
 
 

--- a/train_custom_spacy_model/train_custom_spacy_model.bat
+++ b/train_custom_spacy_model/train_custom_spacy_model.bat
@@ -1,7 +1,8 @@
 @echo off
+FOR /F %%i IN ('python ..\get_model_version.py') DO SET VERSION=%%i
 python train_custom_spacy_model.py
-copy template_meta_spacy_fi_lg.json ..\custom_spacy_model\fi_datahel_spacy-0.0.2\meta.json
-copy template_config_spacy_fi_lg.cfg ..\custom_spacy_model\fi_datahel_spacy-0.0.2\config.cfg
+copy template_meta_spacy_fi_lg.json ..\custom_spacy_model\fi_datahel_spacy-%VERSION%\meta.json
+copy template_config_spacy_fi_lg.cfg ..\custom_spacy_model\fi_datahel_spacy-%VERSION%\config.cfg
 cd ..
 pip install -e custom_spacy_model
 cd train_custom_spacy_model

--- a/train_custom_spacy_model/train_custom_spacy_model.ps1
+++ b/train_custom_spacy_model/train_custom_spacy_model.ps1
@@ -1,6 +1,7 @@
+$VERSION = (python ..\get_model_version.py)
 python .\train_custom_spacy_model.py
-Copy-Item -Path ".\template_meta_spacy_fi_lg.json" -Destination "..\custom_spacy_model\fi_datahel_spacy-0.0.2\meta.json"
-Copy-Item -Path ".\template_config_spacy_fi_lg.cfg" -Destination "..\custom_spacy_model\fi_datahel_spacy-0.0.2\config.cfg"
+Copy-Item -Path ".\template_meta_spacy_fi_lg.json" -Destination "..\custom_spacy_model\fi_datahel_spacy-$VERSION\meta.json"
+Copy-Item -Path ".\template_config_spacy_fi_lg.cfg" -Destination "..\custom_spacy_model\fi_datahel_spacy-$VERSION\config.cfg"
 Set-Location ".."
 pip install -e .\custom_spacy_model
 Set-Location ".\train_custom_spacy_model"

--- a/train_custom_spacy_model/train_custom_spacy_model.py
+++ b/train_custom_spacy_model/train_custom_spacy_model.py
@@ -3,6 +3,8 @@ import datetime
 import itertools
 import os
 import random
+import json
+from pathlib import Path
 
 import spacy
 from spacy.training import Example
@@ -31,7 +33,14 @@ NAME_ENTITY = 'PERSON'
 
 base_model = "fi_core_news_lg"
 nlp = spacy.load(base_model)
-target_path = "../custom_spacy_model/fi_datahel_spacy-0.0.2"
+
+def get_model_version() -> str:
+    meta_path = Path(__file__).resolve().parent.parent / "custom_spacy_model" / "meta.json"
+    with meta_path.open() as f:
+        return json.load(f)["version"]
+
+model_version = get_model_version()
+target_path = f"../custom_spacy_model/fi_datahel_spacy-{model_version}"
 
 this_dir, this_filename = os.path.split(__file__)
 

--- a/train_custom_spacy_model/train_custom_spacy_model.sh
+++ b/train_custom_spacy_model/train_custom_spacy_model.sh
@@ -1,7 +1,9 @@
 #!/bin/sh
+VERSION=$(python ../get_model_version.py)
+
 python ./train_custom_spacy_model.py
-cp template_meta_spacy_fi_lg.json ../custom_spacy_model/fi_datahel_spacy-0.0.2/meta.json
-cp template_config_spacy_fi_lg.cfg ../custom_spacy_model/fi_datahel_spacy-0.0.2/config.cfg
+cp template_meta_spacy_fi_lg.json ../custom_spacy_model/fi_datahel_spacy-${VERSION}/meta.json
+cp template_config_spacy_fi_lg.cfg ../custom_spacy_model/fi_datahel_spacy-${VERSION}/config.cfg
 cd ..
 pip install -e custom_spacy_model
 cd train_custom_spacy_model


### PR DESCRIPTION
## Summary
- add `get_model_version.py` helper
- update training scripts to use the helper for versioned paths
- load model version dynamically in `train_custom_spacy_model.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_684abaaaee3c832781b4390da868c44c