### PR TITLE
Add spaCy model existence checks to tests

### DIFF
--- a/examples/test_recognizers.py
+++ b/examples/test_recognizers.py
@@ -2,6 +2,9 @@ import phonenumbers
 from presidio_analyzer import AnalyzerEngine, RecognizerRegistry
 from presidio_analyzer.nlp_engine import NlpEngineProvider
 from presidio_analyzer.predefined_recognizers import EmailRecognizer, PhoneRecognizer, IpRecognizer, IbanRecognizer
+import json
+from pathlib import Path
+import pytest
 
 from text_anonymizer.recognizers.fi_address_recognizer import FiAddressRecognizer
 from text_anonymizer.recognizers.fi_property_identifier_recognizer import FiRealPropertyIdentifierRecognizer
@@ -16,6 +19,17 @@ TEST_TEXT = "Hello, my name is David. "
 from text_anonymizer.recognizers.fi_ssn_recognizer import FiSsnRecognizer
 
 config_file = "../text_anonymizer/config/languages-config.yml"
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+META_PATH = BASE_DIR / "custom_spacy_model" / "meta.json"
+with META_PATH.open() as f:
+    version = json.load(f)["version"]
+model_path = BASE_DIR / "custom_spacy_model" / f"fi_datahel_spacy-{version}"
+
+if not model_path.exists():
+    pytest.skip(
+        f"spaCy model directory {model_path} not found", allow_module_level=True
+    )
 
 # Create NLP engine based on configuration file
 provider = NlpEngineProvider(conf_file=config_file)

--- a/examples/test_text_anonymizer.py
+++ b/examples/test_text_anonymizer.py
@@ -1,6 +1,9 @@
 # Test
 from text_anonymizer import TextAnonymizer
 import time
+import json
+from pathlib import Path
+import pytest
 
 '''
 Example code to test TextAnonymizer
@@ -8,6 +11,18 @@ Also used in the performance testing.
 '''
 
 ITERATIONS = 10
+
+# Skip test if Finnish spaCy model directory is missing
+BASE_DIR = Path(__file__).resolve().parent.parent
+META_PATH = BASE_DIR / "custom_spacy_model" / "meta.json"
+with META_PATH.open() as f:
+    version = json.load(f)["version"]
+model_path = BASE_DIR / "custom_spacy_model" / f"fi_datahel_spacy-{version}"
+
+if not model_path.exists():
+    pytest.skip(
+        f"spaCy model directory {model_path} not found", allow_module_level=True
+    )
 
 # Init anonymizer to work in mask mode and two languages
 text_anonymizer = TextAnonymizer(languages=['fi'])

--- a/train_custom_spacy_model/test_ner.py
+++ b/train_custom_spacy_model/test_ner.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 
 import spacy
+import pytest
 
 BASE_DIR = Path(__file__).resolve().parent.parent
 META_PATH = BASE_DIR / "custom_spacy_model" / "meta.json"
@@ -12,6 +13,9 @@ with META_PATH.open() as f:
     version = json.load(f)["version"]
 
 model_path = BASE_DIR / "custom_spacy_model" / f"fi_datahel_spacy-{version}"
+
+if not model_path.exists():
+    pytest.skip(f"spaCy model directory {model_path} not found", allow_module_level=True)
 
 nlp = spacy.load(str(model_path))
 


### PR DESCRIPTION
## Summary
- prevent failing tests by checking for Finnish spaCy model before loading
- skip example tests and `test_ner` when the model directory is not present

## Testing
- `pip install -e .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'custom_spacy_model')*

------
https://chatgpt.com/codex/tasks/task_e_684ace8bff7c8327aa434aa74c0b9cbc