### PR TITLE
Fix skip data path for training script

### DIFF
--- a/train_custom_spacy_model/train_custom_spacy_model.py
+++ b/train_custom_spacy_model/train_custom_spacy_model.py
@@ -69,7 +69,7 @@ _ORGANIZATIONS_DATA_FILE = os.path.join(this_dir, _ORGANIZATIONS_FILE_PATH)
 _ORGANIZATIONS = []
 
 _SKIP_FILE_PATH = "../test/data/ohitettavat.txt"
-_SKIP_DATA_FILE = os.path.join(this_dir, _ORGANIZATIONS_FILE_PATH)
+_SKIP_DATA_FILE = os.path.join(this_dir, _SKIP_FILE_PATH)
 _SKIP = []
 
 with open(_LAST_NAMES_DATA_FILE, 'r') as data:


### PR DESCRIPTION
## Summary
- join the directory of the training script with `_SKIP_FILE_PATH`

## Testing
- `pytest -k test_main -q` *(fails: ModuleNotFoundError: No module named 'text_anonymizer')*

------
https://chatgpt.com/codex/tasks/task_e_684ace94f2a883278baea11f5a0afa2f