### PR TITLE
Fix regex pattern quoting

### DIFF
--- a/text_anonymizer/recognizers/fi_spacy_address_recognizer.py
+++ b/text_anonymizer/recognizers/fi_spacy_address_recognizer.py
@@ -20,15 +20,15 @@ class SpacyAddressRecognizer(LocalRecognizer):
     DEFAULT_PATTERNS = [
         [
             {'ENT_TYPE': 'PERSON', 'OP': '+'},
-            {"TEXT": {"REGEX": "([0-9]{1,4}})(\s)?([A-Za-z]{0,1})?(\s)?([0-9]{0,4})?"}, 'OP': '+'}
+            {"TEXT": {"REGEX": r"([0-9]{1,4})(\s)?([A-Za-z]{0,1})?(\s)?([0-9]{0,4})?"}, 'OP': '+'}
         ],
         [
             {'ENT_TYPE': 'LOC', 'OP': '+'},
-            {"TEXT": {"REGEX": "([0-9]{1,4}})(\s)?([A-Za-z]{0,1})?(\s)?([0-9]{0,4})?"}, 'OP': '+'}
+            {"TEXT": {"REGEX": r"([0-9]{1,4})(\s)?([A-Za-z]{0,1})?(\s)?([0-9]{0,4})?"}, 'OP': '+'}
         ],
         [
             {'ENT_TYPE': 'GPE', 'OP': '+'},
-            {"TEXT": {"REGEX": "([0-9]{1,4}})(\s)?([A-Za-z]{0,1})?(\s)?([0-9]{0,4})?"}, 'OP': '+'}
+            {"TEXT": {"REGEX": r"([0-9]{1,4})(\s)?([A-Za-z]{0,1})?(\s)?([0-9]{0,4})?"}, 'OP': '+'}
         ],
         [
             {'ENT_TYPE': 'PERSON', 'OP': '+'},


### PR DESCRIPTION
## Summary
- remove an extra curly bracket in all address regex patterns
- use raw strings to silence escape warnings

## Testing
- `pytest -q` *(fails: Can't find model '/workspace/text-anonymizer/custom_spacy_model/fi_datahel_spacy-0.0.2')*

------
https://chatgpt.com/codex/tasks/task_e_684ace98858c8327bd983be6756d1156