### PR TITLE
Fix spaCy model packaging

### DIFF
--- a/custom_spacy_model/setup.py
+++ b/custom_spacy_model/setup.py
@@ -6,8 +6,7 @@ setup(
     description='Package for custom spacy models.',
     author='DataHel',
     author_email='',
-    packages=[
-
-    ],
+    packages=['custom_spacy_model'],
+    package_dir={'custom_spacy_model': '.'},
     install_requires=[]
 )


### PR DESCRIPTION
## Summary
- ensure `custom_spacy_model` is packaged correctly by setting `packages` and `package_dir`

## Testing
- `pip install ./custom_spacy_model`
- `python -c "import custom_spacy_model, pkgutil; print('ok:',pkgutil.find_loader('custom_spacy_model') is not None)"`
- `pytest -q` *(fails: Can't find model)*

------
https://chatgpt.com/codex/tasks/task_e_684ad12379d48327a218cc25289a695e